### PR TITLE
refactor: adjust search path traversal depth on Linux and Windows

### DIFF
--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -113,7 +113,7 @@ pub fn get_all_apps(search_paths: &[PathBuf]) -> Result<Vec<App>> {
         if !dir.exists() {
             continue;
         }
-        for entry in WalkDir::new(dir.clone()) {
+        for entry in WalkDir::new(dir.clone()).max_depth(1) {
             if entry.is_err() {
                 continue;
             }

--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -319,7 +319,8 @@ mod tests {
 
     #[test]
     fn test_get_apps() {
-        let apps = get_all_apps(&[PathBuf::from("/home")]).unwrap();
+        let default_search_path = get_default_search_paths();
+        let apps = get_all_apps(&default_search_path).unwrap();
         assert!(!apps.is_empty());
     }
 

--- a/src/platforms/windows.rs
+++ b/src/platforms/windows.rs
@@ -341,7 +341,11 @@ pub fn get_all_apps(search_paths: &[PathBuf]) -> Result<Vec<App>> {
             continue;
         }
 
-        for entry in WalkDir::new(search_path).into_iter().filter_map(|e| e.ok()) {
+        for entry in WalkDir::new(search_path)
+            .max_depth(2)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
             let path = entry.path();
             if path.is_file() {
                 if let Some(extension) = path.extension() {

--- a/src/watcher/macos.rs
+++ b/src/watcher/macos.rs
@@ -166,8 +166,7 @@ impl Watcher {
         }
         let owned_fd = open(search_path, OFlag::O_RDONLY, Mode::empty())?;
         let raw_fd = owned_fd.into_raw_fd();
-        self.search_paths
-            .insert(raw_fd, search_path.to_path_buf());
+        self.search_paths.insert(raw_fd, search_path.to_path_buf());
         let kevent = KEvent::new(
             raw_fd as usize,
             EventFilter::EVFILT_VNODE,


### PR DESCRIPTION
Adjust the search path traversal depth:

* Windows: 2
* Linux: 1

No need to do this on macOS, because we are relying on Spotlight to get the app list, i.e., we are not doing directory traversal.