### PR TITLE
refactor: specialized impl for getting apps installed via flatpak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,4 @@ pub mod utils;
 pub mod watcher;
 
 pub use common::{App, AppInfo, AppInfoContext, AppTrait};
-pub use platforms::{get_all_apps, get_default_search_paths, load_icon};
+pub use platforms::{get_all_apps, get_default_search_paths};

--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -198,7 +198,6 @@ mod tests {
         let default_search_path = get_default_search_paths();
         let apps = get_all_apps(&default_search_path).unwrap();
         assert!(!apps.is_empty());
-        println!("DBG: {:#?}", apps);
     }
 
     #[test]

--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -1,65 +1,26 @@
 use crate::common::App;
-use crate::utils::image::{RustImage, RustImageData};
+use crate::utils::image::RustImage;
 use crate::AppTrait;
 use anyhow::Result;
 use freedesktop_file_parser::{parse, EntryType};
 use serde_derive::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::io::{prelude::*, BufReader};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 use walkdir::WalkDir;
+
+const FLATPAK_GLOBAL_APP_PATH: &str = "/var/lib/flatpak/app";
+static FLATPAK_PERSONAL_APP_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
+    let home_dir =
+        PathBuf::from(std::env::var_os("HOME").expect("environment variable $HOME not found"));
+    home_dir.join(".local/share/flatpak/app")
+});
 
 #[derive(Debug, PartialEq, Clone, Default, Eq, Hash, Serialize, Deserialize)]
 pub struct AppIcon {
     name: String,
     path: PathBuf,
     dimensions: Option<u16>,
-}
-
-pub fn brute_force_find_entry(
-    desktop_file_path: &Path,
-    entry_names: Vec<&str>,
-) -> Result<Option<String>> {
-    let file = std::fs::File::open(desktop_file_path)?;
-    let reader = BufReader::new(file);
-
-    for line in reader.lines() {
-        match line {
-            Ok(line) => {
-                for entry_name in entry_names.iter() {
-                    if line.starts_with(entry_name) {
-                        // let entry = line.split("=").last().unwrap();
-                        let entry = line[entry_name.len() + 1..line.len()].trim();
-                        return Ok(Some(entry.to_string()));
-                    }
-                }
-            }
-            Err(_e) => {}
-        }
-    }
-    Ok(None)
-}
-
-/// in case the icon in .desktop file cannot be parsed, use this function to manually find the icon
-/// example /usr/share/applications/microsoft-edge.desktop icon cannot be parsed with ini crate
-pub fn brute_force_find_icon(desktop_file_path: &Path) -> Result<Option<String>> {
-    // read the desktop file into lines and find the icon line
-    brute_force_find_entry(desktop_file_path, vec!["Icon", "icon"])
-}
-
-pub fn brute_force_find_exec(desktop_file_path: &Path) -> Result<Option<String>> {
-    brute_force_find_entry(desktop_file_path, vec!["Exec", "exec"])
-}
-
-/// clean exec path by removing placeholder "%"" args
-/// like %u, %U, %F
-fn clean_exec_path(exec: &str) -> String {
-    let cleaned: Vec<&str> = exec
-        .split_whitespace()
-        .take_while(|s| !s.starts_with('%')) // Take everything up to first % parameter
-        .collect();
-
-    cleaned.join(" ")
 }
 
 pub(crate) fn parse_desktop_file_content(content: &str) -> Option<(String, Option<PathBuf>)> {
@@ -97,23 +58,76 @@ pub fn get_default_search_paths() -> Vec<PathBuf> {
         // Snap
         "/var/lib/snapd/desktop/applications".into(),
         // Flatpak
-        "/var/lib/flatpak/app".into(),
-        home_dir.join(".local/share/flatpak/app"),
+        FLATPAK_GLOBAL_APP_PATH.into(),
+        FLATPAK_PERSONAL_APP_PATH.to_path_buf(),
     ]
+}
+
+/// Specialized implementation for Flatpak
+///
+/// Flatpak Application desktop file path:
+///
+/// ```text
+/// <flatpak_app_path>/<app_identifer>/current/active/files/share/applications/<app_identifier>.desktop
+/// ```
+fn get_flatpak_applications(flatpak_app_path: &Path) -> Result<Vec<App>> {
+    let dir = std::fs::read_dir(flatpak_app_path)?;
+    let mut apps = Vec::new();
+
+    for res_entry in dir {
+        let entry = res_entry?;
+        let app_desktop_file_path = {
+            let mut path = entry.path();
+            path.push("current/active/files/share/applications");
+            let app_identifier = entry
+                .file_name()
+                .into_string()
+                .expect("flatpak app identifier should be UTF-8 encoded");
+            path.push(format!("{}.desktop", app_identifier));
+
+            path
+        };
+
+        if !app_desktop_file_path.try_exists()? {
+            continue;
+        }
+
+        let desktop_file_content = std::fs::read_to_string(&app_desktop_file_path)?;
+        let Some((app_name, opt_icon_path)) = parse_desktop_file_content(&desktop_file_content)
+        else {
+            continue;
+        };
+
+        let app = App {
+            name: app_name,
+            icon_path: opt_icon_path,
+            app_path_exe: None,
+            app_desktop_path: app_desktop_file_path,
+        };
+        apps.push(app);
+    }
+
+    Ok(apps)
 }
 
 pub fn get_all_apps(search_paths: &[PathBuf]) -> Result<Vec<App>> {
     let search_dirs: HashSet<&PathBuf> = search_paths.iter().filter(|dir| dir.exists()).collect();
 
-    let icons_db = find_all_app_icons()?;
-
     // for each dir, search for .desktop files
     let mut apps: HashSet<App> = HashSet::new();
     for dir in search_dirs {
+        // Specialized impl for Flatpak
+        if dir == Path::new(FLATPAK_GLOBAL_APP_PATH) || dir == &*FLATPAK_PERSONAL_APP_PATH {
+            let flatpak_apps = get_flatpak_applications(dir.as_path())?;
+            apps.extend(flatpak_apps);
+
+            continue;
+        }
+
         if !dir.exists() {
             continue;
         }
-        for entry in WalkDir::new(dir.clone()).max_depth(1) {
+        for entry in WalkDir::new(dir.clone()) {
             if entry.is_err() {
                 continue;
             }
@@ -144,133 +158,15 @@ pub fn get_all_apps(search_paths: &[PathBuf]) -> Result<Vec<App>> {
     Ok(apps.iter().cloned().collect())
 }
 
-/// Impl based on https://wiki.archlinux.org/title/Desktop_entries
-pub fn find_all_app_icons() -> Result<HashMap<String, Vec<AppIcon>>> {
-    let mut search_dirs = vec!["/usr/share/icons".into(), "/usr/share/pixmaps".into()];
-    // If $XDG_DATA_DIRS is either not set or empty, a value equal to `/usr/local/share/:/usr/share/` should be used.
-    let xdg_data_dirs =
-        std::env::var("XDG_DATA_DIRS").unwrap_or("/usr/local/share/:/usr/share/".into());
-    for xdg_data_dir in xdg_data_dirs.split(':') {
-        let dir = Path::new(xdg_data_dir).join("icons");
-        search_dirs.push(dir);
-    }
-    // filter out search_dirs that do not exist
-    let search_dirs: Vec<PathBuf> = search_dirs.into_iter().filter(|dir| dir.exists()).collect();
-
-    let mut set = HashSet::new();
-
-    for dir in search_dirs {
-        for entry in WalkDir::new(dir.clone()) {
-            if entry.is_err() {
-                continue;
-            }
-            let entry = entry.unwrap();
-            let path = entry.path();
-            match path.extension() {
-                Some(ext) => {
-                    if ext == "png" {
-                        let path_str = path.to_string_lossy().to_string();
-                        let split: Vec<&str> = path_str.split("/").collect();
-                        let dim_str = if split.len() < 6 {
-                            None
-                        } else {
-                            split[5].split("x").last()
-                        };
-                        let dim = match dim_str {
-                            Some(dim) => match dim.parse::<u16>() {
-                                Ok(dim) => Some(dim),
-                                Err(_) => None,
-                            },
-                            None => None,
-                        };
-                        set.insert(AppIcon {
-                            name: path.file_name().unwrap().to_str().unwrap().to_string(),
-                            path: path.to_path_buf(),
-                            dimensions: dim, // dimensions,
-                        });
-                    }
-                }
-                None => {
-                    continue;
-                }
-            }
-        }
-    }
-    let mut map: HashMap<String, Vec<AppIcon>> = HashMap::new();
-    for icon in set {
-        let name = icon.name.clone();
-        let name = &name[0..name.len() - 4]; // remove .png
-        if map.contains_key(name) {
-            map.get_mut(name).unwrap().push(icon);
-        } else {
-            map.insert(name.to_string(), vec![icon]);
-        }
-    }
-    // sort icons by dimensions
-    for (_, icons) in map.iter_mut() {
-        icons.sort_by(|a, b| {
-            if a.dimensions.is_none() && b.dimensions.is_none() {
-                return std::cmp::Ordering::Equal;
-            }
-            if a.dimensions.is_none() {
-                return std::cmp::Ordering::Greater;
-            }
-            if b.dimensions.is_none() {
-                return std::cmp::Ordering::Less;
-            }
-            b.dimensions.unwrap().cmp(&a.dimensions.unwrap())
-        });
-    }
-    Ok(map)
-}
-
-pub fn open_file_with(file_path: PathBuf, app: App) {
-    let exe_path = app.app_path_exe.unwrap();
-    let exec_path_str = exe_path.to_str().unwrap();
-    let file_path_str = file_path.to_str().unwrap();
-    let output = std::process::Command::new(exec_path_str)
-        .arg(file_path_str)
-        .output()
-        .expect("failed to execute process");
-    if !output.status.success() {
-        panic!("failed to execute process");
-    }
+pub fn get_frontmost_application() -> Result<App> {
+    unimplemented!()
 }
 
 pub fn get_running_apps() -> Vec<App> {
-    todo!()
+    unimplemented!()
 }
-
-/// TODO: this is not working yet, xprop gives the current app name, but we need to locate its .desktop file if possible
-/// If I need to compare app name with app apps, then this function should be moved to AppInfoContext where there is a `cached_apps`
-pub fn get_frontmost_application() -> Result<App> {
-    let output = std::process::Command::new("xprop")
-        .arg("-root")
-        .arg("_NET_ACTIVE_WINDOW")
-        .output()
-        .expect("failed to execute process");
-
-    let output = std::str::from_utf8(&output.stdout).unwrap();
-    let id = output.split_whitespace().last().unwrap();
-
-    let output = std::process::Command::new("xprop")
-        .arg("-id")
-        .arg(id)
-        .arg("WM_CLASS")
-        .output()
-        .expect("failed to execute process");
-
-    let output = std::str::from_utf8(&output.stdout).unwrap();
-    let app_name = output.split('"').nth(1).unwrap();
-
-    let apps = get_all_apps(&vec![])?;
-    for app in apps {
-        if app.name == app_name {
-            return Ok(app);
-        }
-    }
-
-    Err(anyhow::Error::msg("No matching app found".to_string()))
+pub fn open_file_with(_file_path: PathBuf, _app: App) {
+    unimplemented!()
 }
 
 impl AppTrait for App {
@@ -288,49 +184,21 @@ impl AppTrait for App {
         }
     }
 
-    fn from_path(path: &Path) -> Result<Self> {
+    fn from_path(_path: &Path) -> Result<Self> {
         todo!()
     }
 }
 
-/// path should be a .png file, Linux icon can also be a .svg file, don't use this function in that case
-pub fn load_icon(path: &Path) -> Result<RustImageData> {
-    // if path is a .svg file
-    if path.extension().unwrap() == "svg" {
-        return Err(anyhow::anyhow!("SVG files are not supported on Linux yet"));
-    }
-    let image = RustImageData::from_path(path.to_str().unwrap())
-        .map_err(|e| anyhow::anyhow!("Failed to get icon: {}", e))?;
-    Ok(image)
-}
-
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::*;
-
-    #[test]
-    fn test_clean_exec_path() {
-        assert_eq!(clean_exec_path("code %f").to_string(), "code");
-        assert_eq!(clean_exec_path("code %f %F").to_string(), "code");
-        assert_eq!(clean_exec_path("\"/home/hacker/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/bin/idea\" %u").to_string(), "\"/home/hacker/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/bin/idea\"");
-    }
 
     #[test]
     fn test_get_apps() {
         let default_search_path = get_default_search_paths();
         let apps = get_all_apps(&default_search_path).unwrap();
         assert!(!apps.is_empty());
-    }
-
-    #[test]
-    fn test_find_all_app_icons() {
-        let start = std::time::Instant::now();
-        let icons_icons = find_all_app_icons().unwrap();
-        let elapsed = start.elapsed();
-        assert!(!icons_icons.is_empty());
-        println!("Elapsed: {:?}", elapsed);
+        println!("DBG: {:#?}", apps);
     }
 
     #[test]


### PR DESCRIPTION
Add a specialized implementation for retrieving apps installed via Flatpak

This change:
1. Fixes a bug where the same app could be reported twice
  
   Every app installed via flatpak has 2 desktop files under its directory, take `com.google.Chrome` as an example:
   
```sh
$ find . -name "com.google.Chrome.desktop"
./x86_64/stable/ca5617c1195bd48bd3cfae549ea738f5bfc51f78aec1e7b025948339140b6abf/export/share/applications/com.google.Chrome.desktop
./x86_64/stable/ca5617c1195bd48bd3cfae549ea738f5bfc51f78aec1e7b025948339140b6abf/files/share/applications/com.google.Chrome.desktop
```
So our generic implementation will treat these 2 desktop files as 2 apps.
    
2. Improves the performance of the `get_all_apps()` interface