### PR TITLE
feat: get localized app names on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 You can use this crate to:
 
-* Take a snapshot (not a point-in-time view) of the current app list 
+* Get the installed app list 
 * Watch the app list changes

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,11 +3,11 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     path::{Path, PathBuf},
 };
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
 pub struct App {
     /// Base name. Should only be used when the localized app name needed is
     /// not found.
@@ -24,7 +24,7 @@ pub struct App {
     /// zh_HK: Finder
     /// zh_TW: Finder
     /// ```
-    pub localized_app_names: HashMap<String, String>,
+    pub localized_app_names: BTreeMap<String, String>,
     /// Path to the icon file.
     pub icon_path: Option<PathBuf>,
     /// Path to the executable file.

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,13 +2,32 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
 pub struct App {
+    /// Base name. Should only be used when the localized app name needed is
+    /// not found.
+    ///
+    /// On macOS, this will be the "CFBundleDisplayName" or "CFBundleName"
+    /// defined in "Info.plist", or the stem part of the app package's file
+    /// name (Finder.app => Finder).
     pub name: String,
+    /// Localized app names, for example:
+    ///
+    /// ```text
+    /// en: Finder
+    /// zh_CN: 访达
+    /// zh_HK: Finder
+    /// zh_TW: Finder
+    /// ```
+    pub localized_app_names: HashMap<String, String>,
+    /// Path to the icon file.
     pub icon_path: Option<PathBuf>,
-    /// Path to the .app file for mac, or Exec for Linux, or .exe for Windows
+    /// Path to the executable file.
     pub app_path_exe: Option<PathBuf>,
     // Path to the .desktop file for Linux, .app for Mac
     pub app_desktop_path: PathBuf,

--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -3,7 +3,7 @@ use crate::AppTrait;
 use anyhow::Result;
 use freedesktop_file_parser::{parse, EntryType};
 use serde_derive::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -100,7 +100,7 @@ fn get_flatpak_applications(flatpak_app_path: &Path) -> Result<Vec<App>> {
 
         let app = App {
             name: app_name,
-            localized_app_names: HashMap::new(),
+            localized_app_names: BTreeMap::new(),
             icon_path: opt_icon_path,
             app_path_exe: None,
             app_desktop_path: app_desktop_file_path,
@@ -148,7 +148,7 @@ pub fn get_all_apps(search_paths: &[PathBuf]) -> Result<Vec<App>> {
 
                 let app = App {
                     name: app_name,
-                    localized_app_names: HashMap::new(),
+                    localized_app_names: BTreeMap::new(),
                     icon_path: opt_icon_path,
                     app_path_exe: None,
                     app_desktop_path: path.to_path_buf(),
@@ -170,7 +170,7 @@ impl AppTrait for App {
 
         Ok(App {
             name: app_name,
-            localized_app_names: HashMap::new(),
+            localized_app_names: BTreeMap::new(),
             icon_path: opt_icon_path,
             app_path_exe: None,
             app_desktop_path: path.to_path_buf(),

--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -3,6 +3,7 @@ use crate::AppTrait;
 use anyhow::Result;
 use freedesktop_file_parser::{parse, EntryType};
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -99,6 +100,7 @@ fn get_flatpak_applications(flatpak_app_path: &Path) -> Result<Vec<App>> {
 
         let app = App {
             name: app_name,
+            localized_app_names: HashMap::new(),
             icon_path: opt_icon_path,
             app_path_exe: None,
             app_desktop_path: app_desktop_file_path,
@@ -146,6 +148,7 @@ pub fn get_all_apps(search_paths: &[PathBuf]) -> Result<Vec<App>> {
 
                 let app = App {
                     name: app_name,
+                    localized_app_names: HashMap::new(),
                     icon_path: opt_icon_path,
                     app_path_exe: None,
                     app_desktop_path: path.to_path_buf(),
@@ -167,6 +170,7 @@ impl AppTrait for App {
 
         Ok(App {
             name: app_name,
+            localized_app_names: HashMap::new(),
             icon_path: opt_icon_path,
             app_path_exe: None,
             app_desktop_path: path.to_path_buf(),

--- a/src/platforms/windows.rs
+++ b/src/platforms/windows.rs
@@ -140,6 +140,7 @@ fn parse_lnk(path: PathBuf) -> Option<App> {
 
     Some(App {
         name: path.file_stem().unwrap().to_str().unwrap().to_string(),
+        localized_app_names: BTreeMap::new(),
         icon_path,
         app_path_exe: exe,
         app_desktop_path: work_dir,

--- a/src/platforms/windows.rs
+++ b/src/platforms/windows.rs
@@ -7,7 +7,7 @@ use parselnk::string_data;
 use parselnk::Lnk;
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -109,7 +109,7 @@ pub fn parse_lnk_with_powershell_2(lnk_path: PathBuf) -> anyhow::Result<App> {
     };
     let app = App {
         name: name,
-        localized_app_names: HashMap::new(),
+        localized_app_names: BTreeMap::new(),
         icon_path: icon_path,
         app_path_exe: Some(target_path),
         app_desktop_path: desktop_path,
@@ -256,7 +256,7 @@ pub(crate) fn parse_lnk2(path: PathBuf) -> Option<App> {
     let name = path.file_stem().unwrap().to_str().unwrap().to_string();
     Some(App {
         name,
-        localized_app_names: HashMap::new(),
+        localized_app_names: BTreeMap::new(),
         icon_path: icon,
         app_path_exe: Some(exe_path),
         app_desktop_path: work_dir,

--- a/src/utils/mac.rs
+++ b/src/utils/mac.rs
@@ -5,6 +5,7 @@ use glob::glob;
 use plist::Value as PlistValue;
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs::File;
@@ -450,13 +451,13 @@ impl MacAppPath {
         None
     }
 
-    fn get_localized_app_names(&self) -> HashMap<String, String> {
+    fn get_localized_app_names(&self) -> BTreeMap<String, String> {
         // support for iOS apps has not be implemented
         if self.has_wrapper() {
-            return HashMap::new();
+            return BTreeMap::new();
         }
 
-        let mut names = HashMap::new();
+        let mut names = BTreeMap::new();
         let resources_path = self.0.join("Contents/Resources");
 
         // InfoPlist.loctable is a modern replace for those "*.lproj" folders.
@@ -480,7 +481,7 @@ fn read_loctable(path: &Path) -> Result<PlistValue, String> {
     PlistValue::from_reader(reader).map_err(|e| format!("Failed to parse plist: {}", e))
 }
 
-fn extract_names_from_loctable(loctable: &PlistValue, names: &mut HashMap<String, String>) {
+fn extract_names_from_loctable(loctable: &PlistValue, names: &mut BTreeMap<String, String>) {
     // Look for CFBundleDisplayName or CFBundleName in different locales
     if let Some(dict) = loctable.as_dictionary() {
         for (locale, value) in dict {
@@ -569,7 +570,7 @@ fn infoplist_strings_parser(path: &Path) -> HashMap<String, String> {
 
 fn extract_from_all_lproj_dirs(
     resources_path: &Path,
-    names: &mut HashMap<String, String>,
+    names: &mut BTreeMap<String, String>,
 ) -> Result<(), String> {
     const LPROJ: &str = ".lproj";
 


### PR DESCRIPTION
This commit adds a new field "localized_app_names" to the "struct App" type, which will contain the localized app names. For example, here is the list for the built-in Clock.app:

```text
ar: الساعة
ca: Rellotge
cs: Hodiny
da: Ur
de: Uhr
el: Ρολόι
en: Clock
en_AU: Clock
en_GB: Clock
es: Reloj
es_419: Reloj
es_US: Reloj
fi: Kello
fr: Horloge
fr_CA: Horloge
he: שעון
hi: घड़ी
hr: Sat
hu: Óra
id: Jam
it: Orologio
ja: 時計
ko: 시계
ms: Jam
nl: Klok
no: Klokke
pl: Zegar
pt_BR: Relógio
pt_PT: Relógio
ro: Ceas
ru: Часы
sk: Hodiny
sl: Ura
sv: Klocka
th: นาฬิกา
tr: Saat
uk: Годинник
vi: Đồng hồ
zh_CN: 时钟
zh_HK: 時鐘
zh_TW: 時鐘
```